### PR TITLE
clarify working node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,13 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app) to give you a quick starting place for the exercise. You can use the provided code or use a different framework/language for the front-end. You will need to provide all code for the back-end using which ever framework/language you are most comfortable with.
 
-
 ## Exercise Description
 
 Image that you have been hired to create a new Real Estate application to help consumers purchase a home. Your new company is up against the a tight timeline and needs to deliver a minimum viable product (mvp) ASAP! In order to compete in the market place your MVP should provide the following core functionality:
 
-- View/browse all available homes 
+- View/browse all available homes
 - Filter homes by City, Price, Number of Bedrooms
 - Show detailed view for a selected home
-
 
 ## Solution Details
 
@@ -20,8 +18,7 @@ Create a detailed web app that solves for the following:
 - appropriate handling of flow/navigation
 - appropirate handling of data/state
 
-A sample [data set](./src/homes.json) representing properties has been included to help get you started on what a data model and API call would likely return for the list of active properties. Your solution should include frontend and backend code that solves for the above requirements. 
-
+A sample [data set](./src/homes.json) representing properties has been included to help get you started on what a data model and API call would likely return for the list of active properties. Your solution should include frontend and backend code that solves for the above requirements.
 
 ## Submitting the Exercise
 
@@ -30,7 +27,6 @@ A sample [data set](./src/homes.json) representing properties has been included 
 2. Please make sure the repo is public. If you prefer to keep your repo private, then ensure you have granted read access to [tonyhernandez](https://github.com/tonyhernandez).
 
 3. Completed the Google Form [here](https://forms.gle/We7VGi73apbECGKL6) once you are done with the code. Once submitted do not make any further changes to the code!
-
 
 ## Available Scripts
 
@@ -43,6 +39,8 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 The page will reload if you make edits.\
 You will also see any lint errors in the console.
+
+- Note that this is a development server and has only been tested to be working on Node v16. Node v17+ WILL BREAK THE APP. Please use a version manager like [nvm](https://github.com/nvm-sh/nvm) or [Volta](https://volta.sh/) to manage your Node version as appropriate.
 
 ### `npm run build`
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
       "react-app/jest"
     ]
   },
+  "engines": {
+    "npm": ">=7.0.0",
+    "node": ">=16.0.0"
+  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
Hi. There're breaking packages when running the starter on Node v17. I added a note to the README to clarify this, and to tell the developers to use a Node version manager (as well as links/suggestions) then set to v16. I've also added engines in the `package.json`.


As time is tight, I'm not going to update the packages as I'm using another framework and need to deeply document that one too. Thus', the following error may help if you want to fix this up and update for Node v17. It's something with PostCSS, but there may be other export errors when that is updated.

```
node:internal/modules/cjs/loader:488
      throw e;
      ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/tokenize' is not defined by "exports"
```

If you think that people should figure this out themselves, should they use this starter's CRA (when this would be just as suitable on Next.js) that's cool too.

Regards,
Fang🦁